### PR TITLE
Add navigation to about us section on clicking about us button in header.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@ body {
   padding-bottom: 70px;
   padding-top:70px;
 }
+
+html {
+  scroll-behavior: smooth;
+}

--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -27,10 +27,9 @@
 }
 .nav-links {
   display: flex;
-  gap: 5rem;
+  gap: 3rem;
   flex-wrap: wrap;
   margin-left: auto;
-  margin-right: 20rem;
 }
 
 .nav-button {
@@ -49,25 +48,25 @@
 }
 @media (max-width: 768px) {
   .header-container {
+    display: flex;
     flex-direction: row;
-    align-items: flex-start;
-    padding: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.3rem 2rem;
   }
 
   .nav-links {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 1rem;
-    margin-top: 1rem;
+    gap: 2rem;
     margin-left: 0;
     margin-right: 0;
-    justify-content: flex-start;
   }
 
   .nav-button {
     width: auto;
     text-align: center;
     font-size: 1rem;
-    padding: 0.6rem 1.4rem;
+    padding: 0.4rem 1.4rem;
   }
 }

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
  <header class="header">
   <div class="header-container">
-  <div class="logo-group">
-      <%= image_tag("logo.png", alt: "SkyReady Logo", class: "logo-img") %>
-  </div>
-  <nav class="nav-links">
-      <%= link_to "Home", root_path, class: "nav-button" %>
-      <%= link_to "About Us", "#", class: "nav-button" %>
-  </nav>
+    <div class="logo-group">
+        <%= image_tag("logo.png", alt: "SkyReady Logo", class: "logo-img") %>
+    </div>
+    <nav class="nav-links">
+        <%= link_to "Home", root_path, class: "nav-button" %>
+        <%= link_to "About Us", "#about-us", class: "nav-button" %>
+    </nav>
   </div>
 </header>

--- a/spec/views/shared/_header.html.erb_spec.rb
+++ b/spec/views/shared/_header.html.erb_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe "shared/_header.html.erb", type: :view do
     expect(rendered).to have_link("Home", href: root_path, class: "nav-button")
   end
   it "renders the About Us link with correct text, href and class" do
-    expect(rendered).to have_link("About Us", href: "#", class: "nav-button")
+    expect(rendered).to have_link("About Us", href: "#about-us", class: "nav-button")
   end
 end


### PR DESCRIPTION
## 📌 What does this PR do?
- This pull request adds navigation to about us section when user clicks on about us button in header.

### ✍️ Changes Made 
- Added link to about us section for about us button in header.
- Added smooth scrolling for navigation to about us section.
- Updated styling for header with proper responsiveness.

### 🧪 Testing
- All the code updated in this PR is unit tested using `RSpec` and everything is working as expected.

### 🌐 UI


https://github.com/user-attachments/assets/65cf6d85-0c36-4d8f-83ea-c487ad0a2808



Thank you 😊 !