### PR TITLE
Disable previous dates in the selection of departure date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: 
       - main
-      - feature/available-seats
+      - disable/previous-date
 
 jobs:
   scan_ruby:

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -33,12 +33,13 @@
           name="departure_date"
           class="date-picker"
           value="<%= params[:departure_date].presence || Date.today.strftime('%Y-%m-%d') %>"
+          min="<%= Date.today.strftime('%Y-%m-%d') %>"
         />
       </div>
       <div class="input-field">
         <label>&nbsp;</label>
         <div class="search-button-wrapper">
-          <%= submit_tag "Search", class: "search-button" %>
+        <%= submit_tag "Search", class: "search-button" %>
         </div>
       </div>
       </div>

--- a/spec/views/shared/_search.html.erb_spec.rb
+++ b/spec/views/shared/_search.html.erb_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe "shared/_search.html.erb", type: :view do
     })
   end
 
-  it "renders the search form with correct fields, values, and dropdown options" do
+  it "renders the search form with correct fields, values, dropdown options, and min attribute for date" do
     render partial: "shared/search"
+
+    today = Date.today.strftime("%Y-%m-%d")
 
     expect(rendered).to have_selector("form[action='/'][method='get']")
 
@@ -25,19 +27,20 @@ RSpec.describe "shared/_search.html.erb", type: :view do
     expect(rendered).to include("Hyderabad")
     expect(rendered).to include("Goa")
 
-    expect(rendered).to have_selector("input#departure_date[name='departure_date'][type='date'][value='2025-07-07']")
+    expect(rendered).to have_selector("input#departure_date[name='departure_date'][type='date'][value='2025-07-07'][min='#{today}']")
 
     expect(rendered).to have_selector("input[type='submit'][value='Search'].search-button")
 
     expect(rendered).to have_selector("div#search-error.search-error")
   end
 
-  it "renders today's date in the date picker if no departure_date param is present" do
+  it "renders today's date as value and min attribute when no departure_date param is present" do
     allow(view).to receive(:params).and_return({ source: "", destination: "" })
 
     render partial: "shared/search"
 
     today = Date.today.strftime("%Y-%m-%d")
-    expect(rendered).to have_selector("input#departure_date[value='#{today}']")
+
+    expect(rendered).to have_selector("input#departure_date[value='#{today}'][min='#{today}']")
   end
 end


### PR DESCRIPTION
## This PR adds

- Disabling of previous dates in the current month, while selecting the departure date.

- Updated test cases as per the updated functionality.

## Output Image: Today's date is 07/07/2025, and the previous dates are disabled.
<img width="239" alt="Screenshot 2025-07-07 at 10 50 17 PM" src="https://github.com/user-attachments/assets/e4974f5d-ece8-47bb-99fb-0dc68773c082" />

